### PR TITLE
Set path on expiry cookie

### DIFF
--- a/actix-web-flash-messages/src/storage/cookies.rs
+++ b/actix-web-flash-messages/src/storage/cookies.rs
@@ -160,6 +160,8 @@ impl FlashMessageStore for CookieMessageStore {
             // any pre-existing cookie with a new value.
             let removal_cookie = Cookie::build(self.cookie_name.clone(), "")
                 .max_age(time::Duration::seconds(0))
+                // In the future, consider making the `path` configurable - either globally or on a per-endpoint basis
+                .path("/")
                 .finish();
             response_head
                 .add_cookie(&removal_cookie)


### PR DESCRIPTION
I've been running into some issues with my flash messages not expiring correctly when running unit tests (the same issue doesn't seem to happen when testing manually in the browser for some reason).

I've been able to test that the issue disappears if I set the path of the expiry cookie to be the same as the path on the original cookie. I'm not 100% sure what is going on here, but my theory is that the cookie is not being deleted correctly when identified by only name and not path, and this answer from stack-overflow seems to suggest that is the case: https://stackoverflow.com/a/23995984