### PR TITLE
Add #[must_use] attribute to FlashMessage

### DIFF
--- a/actix-web-flash-messages/src/flash_message.rs
+++ b/actix-web-flash-messages/src/flash_message.rs
@@ -12,6 +12,7 @@ use std::fmt::{Debug, Display, Formatter};
 ///
 /// You can build a flash message via [`FlashMessage::new`] by specifying its content and [`Level`].
 /// You can also use the shorter level-based constructors - e.g. [`FlashMessage::info`].
+#[must_use = "You must call `.send()` on a `FlashMessage` for it to have an effect"]
 pub struct FlashMessage {
     content: String,
     level: Level,


### PR DESCRIPTION
This commit adds the `#[must_use]` attribute to `FlashMessage` so that a warning is displayed when a user constructs a message without calling `send()`.

`FlashMessage` is a good candidate for a `#[must_use]` attribute, as constructing it by itself with `FlashMessage::new(...)` or one of its level-specific constructors has no effect; you must call `.send()` in order to ensure it is sent.

An example of the warning produced after this commit:

```
warning: unused `FlashMessage` that must be used
  --> src/main.rs:19:5
   |
19 |     FlashMessage::info("Should have warning!");
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_must_use)]` on by default
   = note: You must call `.send()` on a `FlashMessage` for it to have an effect
```