### PR TITLE
Add additional builder for cookie settings

### DIFF
--- a/actix-web-flash-messages/src/storage/cookies.rs
+++ b/actix-web-flash-messages/src/storage/cookies.rs
@@ -22,6 +22,7 @@ pub struct CookieMessageStore {
     signing_key: Key,
     bytes_size_limit: u32,
     path: String,
+    domain: String,
 }
 
 /// A fluent builder to construct a [`CookieMessageStore`] instance.
@@ -30,6 +31,7 @@ pub struct CookieMessageStoreBuilder {
     signing_key: Key,
     bytes_size_limit: Option<u32>,
     path: Option<String>,
+    domain: Option<String>,
 }
 
 impl CookieMessageStore {
@@ -44,6 +46,7 @@ impl CookieMessageStore {
             signing_key,
             bytes_size_limit: None,
             path: None,
+            domain: None,
         }
     }
 
@@ -81,6 +84,7 @@ impl CookieMessageStore {
                 .http_only(true)
                 .same_site(SameSite::Lax)
                 .path(&self.path)
+                .domain(&self.domain)
                 .finish();
 
             Ok(signed_cookie)
@@ -130,6 +134,12 @@ impl CookieMessageStoreBuilder {
         self
     }
 
+    /// By default, domain is set to "".
+    pub fn domain(mut self, domain: String) -> Self {
+        self.domain = Some(domain);
+        self
+    }
+
     /// Finalise the builder and return a [`CookieMessageStore`] instance.
     pub fn build(self) -> CookieMessageStore {
         CookieMessageStore {
@@ -137,6 +147,7 @@ impl CookieMessageStoreBuilder {
             signing_key: self.signing_key,
             bytes_size_limit: self.bytes_size_limit.unwrap_or(2048),
             path: self.path.unwrap_or_else(|| "/".to_string()),
+            domain: self.domain.unwrap_or_else(|| "".to_string()),
         }
     }
 }

--- a/actix-web-flash-messages/src/storage/cookies.rs
+++ b/actix-web-flash-messages/src/storage/cookies.rs
@@ -24,6 +24,7 @@ pub struct CookieMessageStore {
     secure: bool,
     same_site: SameSite,
     http_only: bool,
+    path: String,
 }
 
 /// A fluent builder to construct a [`CookieMessageStore`] instance.
@@ -34,6 +35,7 @@ pub struct CookieMessageStoreBuilder {
     secure: Option<bool>,
     same_site: Option<SameSite>,
     http_only: Option<bool>,
+    path: Option<String>,
 }
 
 impl CookieMessageStore {
@@ -50,6 +52,7 @@ impl CookieMessageStore {
             secure: None,
             same_site: None,
             http_only: None,
+            path: None,
         }
     }
 
@@ -86,8 +89,7 @@ impl CookieMessageStore {
                 .secure(self.secure)
                 .http_only(self.http_only)
                 .same_site(self.same_site)
-                // In the future, consider making the `path` configurable - either globally or on a per-endpoint basis
-                .path("/")
+                .path(&self.path)
                 .finish();
 
             Ok(signed_cookie)
@@ -149,6 +151,12 @@ impl CookieMessageStoreBuilder {
         self
     }
 
+    /// By default, path is set to "/".
+    pub fn path(mut self, path: String) -> Self {
+        self.path = Some(path);
+        self
+    }
+
     /// Finalise the builder and return a [`CookieMessageStore`] instance.
     pub fn build(self) -> CookieMessageStore {
         CookieMessageStore {
@@ -158,6 +166,7 @@ impl CookieMessageStoreBuilder {
             secure: self.secure.unwrap_or(true),
             same_site: self.same_site.unwrap_or(SameSite::Lax),
             http_only: self.http_only.unwrap_or(true),
+            path: self.path.unwrap_or_else(|| "/".to_string()),
         }
     }
 }

--- a/actix-web-flash-messages/src/storage/cookies.rs
+++ b/actix-web-flash-messages/src/storage/cookies.rs
@@ -23,6 +23,7 @@ pub struct CookieMessageStore {
     bytes_size_limit: u32,
     secure: bool,
     same_site: SameSite,
+    http_only: bool,
 }
 
 /// A fluent builder to construct a [`CookieMessageStore`] instance.
@@ -32,6 +33,7 @@ pub struct CookieMessageStoreBuilder {
     bytes_size_limit: Option<u32>,
     secure: Option<bool>,
     same_site: Option<SameSite>,
+    http_only: Option<bool>,
 }
 
 impl CookieMessageStore {
@@ -47,6 +49,7 @@ impl CookieMessageStore {
             bytes_size_limit: None,
             secure: None,
             same_site: None,
+            http_only: None,
         }
     }
 
@@ -81,7 +84,7 @@ impl CookieMessageStore {
         } else {
             let signed_cookie = Cookie::build(&self.cookie_name, encoded_value)
                 .secure(self.secure)
-                .http_only(true)
+                .http_only(self.http_only)
                 .same_site(self.same_site)
                 // In the future, consider making the `path` configurable - either globally or on a per-endpoint basis
                 .path("/")
@@ -134,6 +137,11 @@ impl CookieMessageStoreBuilder {
         self
     }
 
+    /// By default, http_only is set to true.
+    pub fn http_only(mut self, http_only: bool) -> Self {
+        self.http_only = Some(http_only);
+        self
+    }
     
     /// By default, same_site is set to SameSite::Lax.
     pub fn same_site(mut self, same_site: SameSite) -> Self {
@@ -148,7 +156,8 @@ impl CookieMessageStoreBuilder {
             signing_key: self.signing_key,
             bytes_size_limit: self.bytes_size_limit.unwrap_or(2048),
             secure: self.secure.unwrap_or(true),
-            same_site: self.same_site.unwrap_or(SameSite::Lax)
+            same_site: self.same_site.unwrap_or(SameSite::Lax),
+            http_only: self.http_only.unwrap_or(true),
         }
     }
 }

--- a/actix-web-flash-messages/src/storage/cookies.rs
+++ b/actix-web-flash-messages/src/storage/cookies.rs
@@ -131,7 +131,7 @@ impl CookieMessageStoreBuilder {
         self
     }
 
-    /// By default, path is set to "/".
+    /// By default, the [`Path` attribute](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent) is set to "/".
     pub fn path(mut self, path: String) -> Self {
         self.path = Some(path);
         self

--- a/actix-web-flash-messages/src/storage/cookies.rs
+++ b/actix-web-flash-messages/src/storage/cookies.rs
@@ -22,6 +22,7 @@ pub struct CookieMessageStore {
     signing_key: Key,
     bytes_size_limit: u32,
     secure: bool,
+    same_site: SameSite,
 }
 
 /// A fluent builder to construct a [`CookieMessageStore`] instance.
@@ -30,6 +31,7 @@ pub struct CookieMessageStoreBuilder {
     signing_key: Key,
     bytes_size_limit: Option<u32>,
     secure: Option<bool>,
+    same_site: Option<SameSite>,
 }
 
 impl CookieMessageStore {
@@ -44,6 +46,7 @@ impl CookieMessageStore {
             signing_key,
             bytes_size_limit: None,
             secure: None,
+            same_site: None,
         }
     }
 
@@ -79,7 +82,7 @@ impl CookieMessageStore {
             let signed_cookie = Cookie::build(&self.cookie_name, encoded_value)
                 .secure(self.secure)
                 .http_only(true)
-                .same_site(SameSite::Lax)
+                .same_site(self.same_site)
                 // In the future, consider making the `path` configurable - either globally or on a per-endpoint basis
                 .path("/")
                 .finish();
@@ -131,6 +134,13 @@ impl CookieMessageStoreBuilder {
         self
     }
 
+    
+    /// By default, same_site is set to SameSite::Lax.
+    pub fn same_site(mut self, same_site: SameSite) -> Self {
+        self.same_site = Some(same_site);
+        self
+    }
+
     /// Finalise the builder and return a [`CookieMessageStore`] instance.
     pub fn build(self) -> CookieMessageStore {
         CookieMessageStore {
@@ -138,6 +148,7 @@ impl CookieMessageStoreBuilder {
             signing_key: self.signing_key,
             bytes_size_limit: self.bytes_size_limit.unwrap_or(2048),
             secure: self.secure.unwrap_or(true),
+            same_site: self.same_site.unwrap_or(SameSite::Lax)
         }
     }
 }

--- a/actix-web-flash-messages/src/storage/cookies.rs
+++ b/actix-web-flash-messages/src/storage/cookies.rs
@@ -137,7 +137,7 @@ impl CookieMessageStoreBuilder {
         self
     }
 
-    /// By default, domain is set to None.
+    /// By default, the [`Domain` attribute](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent) is set to `None`.
     pub fn domain(mut self, domain: String) -> Self {
         self.domain = Some(domain);
         self

--- a/actix-web-flash-messages/src/storage/cookies.rs
+++ b/actix-web-flash-messages/src/storage/cookies.rs
@@ -21,6 +21,7 @@ pub struct CookieMessageStore {
     cookie_name: String,
     signing_key: Key,
     bytes_size_limit: u32,
+    secure: bool,
 }
 
 /// A fluent builder to construct a [`CookieMessageStore`] instance.
@@ -28,6 +29,7 @@ pub struct CookieMessageStoreBuilder {
     cookie_name: Option<String>,
     signing_key: Key,
     bytes_size_limit: Option<u32>,
+    secure: Option<bool>,
 }
 
 impl CookieMessageStore {
@@ -41,6 +43,7 @@ impl CookieMessageStore {
             cookie_name: None,
             signing_key,
             bytes_size_limit: None,
+            secure: None,
         }
     }
 
@@ -74,7 +77,7 @@ impl CookieMessageStore {
             )))
         } else {
             let signed_cookie = Cookie::build(&self.cookie_name, encoded_value)
-                .secure(true)
+                .secure(self.secure)
                 .http_only(true)
                 .same_site(SameSite::Lax)
                 // In the future, consider making the `path` configurable - either globally or on a per-endpoint basis
@@ -122,12 +125,19 @@ impl CookieMessageStoreBuilder {
         self
     }
 
+    /// By default, secure is set to true.
+    pub fn secure(mut self, secure: bool) -> Self {
+        self.secure = Some(secure);
+        self
+    }
+
     /// Finalise the builder and return a [`CookieMessageStore`] instance.
     pub fn build(self) -> CookieMessageStore {
         CookieMessageStore {
             cookie_name: self.cookie_name.unwrap_or_else(|| "_flash".to_string()),
             signing_key: self.signing_key,
             bytes_size_limit: self.bytes_size_limit.unwrap_or(2048),
+            secure: self.secure.unwrap_or(true),
         }
     }
 }

--- a/actix-web-flash-messages/src/storage/cookies.rs
+++ b/actix-web-flash-messages/src/storage/cookies.rs
@@ -137,7 +137,7 @@ impl CookieMessageStoreBuilder {
         self
     }
 
-    /// By default, the [`Domain` attribute](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent) is set to `None`.
+    /// By default, the [`Domain` attribute](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent) is left unset.
     pub fn domain(mut self, domain: String) -> Self {
         self.domain = Some(domain);
         self

--- a/actix-web-flash-messages/src/storage/cookies.rs
+++ b/actix-web-flash-messages/src/storage/cookies.rs
@@ -21,9 +21,6 @@ pub struct CookieMessageStore {
     cookie_name: String,
     signing_key: Key,
     bytes_size_limit: u32,
-    secure: bool,
-    same_site: SameSite,
-    http_only: bool,
     path: String,
 }
 
@@ -32,9 +29,6 @@ pub struct CookieMessageStoreBuilder {
     cookie_name: Option<String>,
     signing_key: Key,
     bytes_size_limit: Option<u32>,
-    secure: Option<bool>,
-    same_site: Option<SameSite>,
-    http_only: Option<bool>,
     path: Option<String>,
 }
 
@@ -49,9 +43,6 @@ impl CookieMessageStore {
             cookie_name: None,
             signing_key,
             bytes_size_limit: None,
-            secure: None,
-            same_site: None,
-            http_only: None,
             path: None,
         }
     }
@@ -86,9 +77,9 @@ impl CookieMessageStore {
             )))
         } else {
             let signed_cookie = Cookie::build(&self.cookie_name, encoded_value)
-                .secure(self.secure)
-                .http_only(self.http_only)
-                .same_site(self.same_site)
+                .secure(true)
+                .http_only(true)
+                .same_site(SameSite::Lax)
                 .path(&self.path)
                 .finish();
 
@@ -133,24 +124,6 @@ impl CookieMessageStoreBuilder {
         self
     }
 
-    /// By default, secure is set to true.
-    pub fn secure(mut self, secure: bool) -> Self {
-        self.secure = Some(secure);
-        self
-    }
-
-    /// By default, http_only is set to true.
-    pub fn http_only(mut self, http_only: bool) -> Self {
-        self.http_only = Some(http_only);
-        self
-    }
-    
-    /// By default, same_site is set to SameSite::Lax.
-    pub fn same_site(mut self, same_site: SameSite) -> Self {
-        self.same_site = Some(same_site);
-        self
-    }
-
     /// By default, path is set to "/".
     pub fn path(mut self, path: String) -> Self {
         self.path = Some(path);
@@ -163,9 +136,6 @@ impl CookieMessageStoreBuilder {
             cookie_name: self.cookie_name.unwrap_or_else(|| "_flash".to_string()),
             signing_key: self.signing_key,
             bytes_size_limit: self.bytes_size_limit.unwrap_or(2048),
-            secure: self.secure.unwrap_or(true),
-            same_site: self.same_site.unwrap_or(SameSite::Lax),
-            http_only: self.http_only.unwrap_or(true),
             path: self.path.unwrap_or_else(|| "/".to_string()),
         }
     }

--- a/actix-web-flash-messages/src/storage/cookies.rs
+++ b/actix-web-flash-messages/src/storage/cookies.rs
@@ -86,8 +86,8 @@ impl CookieMessageStore {
                 .path(&self.path)
                 .finish();
 
-            if self.domain.is_some() {
-                signed_cookie.set_domain(self.domain.as_ref().unwrap())
+            if let Some(domain) = &self.domain {
+                signed_cookie.set_domain(domain);
             }
 
             Ok(signed_cookie)


### PR DESCRIPTION
Hi,
I'm proposing to add builder options for the rest of the cookie settings in CookieMessageStore.  It's useful to be able to set these, for example when testing without https, etc.  Please let me know, if there is anything I can do to improve this.
All best,
Jeremy
